### PR TITLE
waffle.io Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,1 +1,4 @@
+.. image:: https://badge.waffle.io/usebenchmark/benchmark-places.png?label=ready&title=Ready 
+ :target: https://waffle.io/usebenchmark/benchmark-places
+ :alt: 'Stories in Ready'
 # benchmarkplaces


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/usebenchmark/benchmark-places

This was requested by a real person (user kennethkoontz) on waffle.io, we're not trying to spam you.
